### PR TITLE
refactoring to storage splitting by function

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -254,6 +254,7 @@
                   |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |JdMHSnIq2ws)
                   |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |value) (:id |BLuoQYoSvI9)
                   |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1593965021557) (:text |*cache-states) (:id |aztyIEL9_)
+                  |L $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314271960) (:text |f) (:id |7q-ZEf88i)
                 :id |ATHw_iTKI9P
               |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                 :data $ {}
@@ -283,87 +284,188 @@
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |ko0L5_njcgn)
                             :id |BzPdfILe6bY
-                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314287165)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |if) (:id |yCay9m4pxeq)
-                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                              |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314288920) (:text |if) (:id |5eKmMyztsH)
+                              |L $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314289212)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |contains?) (:id |TZAqvYvZ0gQ)
-                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |i1NWVD9h01u)
-                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |WFRSS1UcZ2y)
-                                :id |tY9OXhG6R8m
-                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314297096) (:text |contains?) (:id |mkIrx0qxRP)
+                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314301487) (:text |caches) (:id |VVuxI9bBxn)
+                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314302214) (:text |f) (:id |fPkxaPkVcR)
+                                :id |iCwPJjO8y
+                              |P $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314335049)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |do) (:id |xeyT4q1EdAH)
-                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314336764) (:text |let) (:id |i3d3L7cmMhleaf)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314337016)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |println) (:id |JCpvEAFkxzW)
-                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text "|\"[Respo Caches] already exisits") (:id |-luU2XAfVMy)
-                                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |arEv9_5gE7K)
-                                    :id |PfSKYl-xbkE
-                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |update) (:id |8gla-523tPg)
-                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |udT8tGLLOBc)
-                                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |u4KRNkiWqL9)
-                                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                      |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314337176)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |fn) (:id |hBI-JoVPHoq)
-                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314351239) (:text |caller-info) (:id |72HOWYZuiP)
+                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314352163)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |W30xSduFNib)
-                                            :id |B5ApJ_uI-nY
-                                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |->) (:id |dTqR06A8M4U)
-                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |8vkWyhYVnFl)
-                                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |assoc) (:id |n3duMQ0eNHm)
-                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:last-hit) (:id |NfxqrCB14Ul)
-                                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |the-loop) (:id |FOXUoyNWOE9)
-                                                :id |AHNkmk9vdD7
-                                              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |update) (:id |CG8pboLpWFO)
-                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:hit-times) (:id |nLsQ0-I9zKA)
-                                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |inc) (:id |q1-Z4-KYlZx)
-                                                :id |Lb7XFgWNyG5
-                                            :id |nIt0yJPB_mV
-                                        :id |tnqwlAiJMWm
-                                    :id |Kk1GB1Li98p
-                                :id |86-d99cIff1
-                              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |assoc) (:id |YF1zmb-0oOc)
-                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |locs3LE5pM0)
-                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |SQd4bbMUb6o)
-                                  |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314353811) (:text |get) (:id |vjjAdu7F1G)
+                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314355076) (:text |caches) (:id |PUDuzZFWWX)
+                                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314355596) (:text |f) (:id |hrHpMzcbqo)
+                                            :id |6rQWIiIpA
+                                        :id |vWwNuFqMB
+                                    :id |Q-zx5hv--6
+                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314358977)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |{}) (:id |oajKcycGrOl)
-                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314359450) (:text |if) (:id |6K8ZdADhpleaf)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314359767)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:value) (:id |S5rV0-YPHSv)
-                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |value) (:id |lPelgbTcUaN)
-                                        :id |AkO9CsL6BzT
-                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314456341) (:text |contains?) (:id |Gtr17P6eKK)
+                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314456596)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314458560) (:text |:caches) (:id |ZRvlA0Wpr-)
+                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314461487) (:text |caller-info) (:id |wiG5cqm6wA)
+                                            :id |07Yjb9lcjW
+                                          |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314464987) (:text |params) (:id |IRRMRtGbWW)
+                                        :id |hFGI9hvK4V
+                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314482666)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:initial-loop) (:id |dYK4-5CGV7V)
-                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |the-loop) (:id |ZLV1yXAHFud)
-                                        :id |C32BYREmfGE
-                                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314490919) (:text |do) (:id |2QzDjcNAhleaf)
+                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314503882)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314503882) (:text |println) (:id |en-aL_V0W8)
+                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314503882) (:text "|\"[Respo Caches] already exisits") (:id |FXfj97eTzZ)
+                                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314503882) (:text |params) (:id |5ZmBENJbq6)
+                                              |v $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314518383) (:text "|\"for") (:id |7oi7fjNcGM)
+                                              |x $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314509574) (:text |f) (:id |S0iOD0g1i)
+                                            :id |gcfMXeTGLN
+                                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314542596)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314543840) (:text |update-in) (:id |6167qYQmE)
+                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314550575) (:text |caches) (:id |mGxGaXmdgR)
+                                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314550877)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314551146) (:text |[]) (:id |CzpCnM68fe)
+                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314552729) (:text |f) (:id |67JOgKMr6Q)
+                                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314555658) (:text |:caches) (:id |Rh81epPwGz)
+                                                  |v $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314557825) (:text |params) (:id |SE1dsD9yzi)
+                                                :id |4z-ZTkKpVN
+                                              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314566823)
+                                                :data $ {}
+                                                  |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314564334)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314565075) (:text |info) (:id |GoP3AM0ozleaf)
+                                                    :id |GoP3AM0oz
+                                                  |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314567422) (:text |fn) (:id |W-9UOJutD)
+                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314570986)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314570986) (:text |->) (:id |HRphaYaDxC)
+                                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314570986) (:text |info) (:id |vA-oL1zbkq)
+                                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314570986)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314570986) (:text |assoc) (:id |foBaRAytS_)
+                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314570986) (:text |:last-hit) (:id |esqxqpGcst)
+                                                          |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314570986) (:text |the-loop) (:id |S8TA9OVO3Q)
+                                                        :id |d8TaViYt9b
+                                                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314570986)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314570986) (:text |update) (:id |PvVP4TkWoS)
+                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314570986) (:text |:hit-times) (:id |_uKyoZXzDd)
+                                                          |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314570986) (:text |inc) (:id |t-EoYS-wjA)
+                                                        :id |RKOcKfOtgn
+                                                    :id |DC9xix7Q9v
+                                                :id |SzUHbUwoed
+                                            :id |lt3w51PGK
+                                        :id |2QzDjcNAh
+                                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314589444)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:last-hit) (:id |xvz393QuKDw)
-                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |the-loop) (:id |3Zb0J78pbm6)
-                                        :id |NgIelzuAZlw
-                                      |x $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314590871) (:text |assoc-in) (:id |Nu7YXxtFeleaf)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314593346) (:text |caches) (:id |ZLdqN5c2j)
+                                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314594692)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314594880) (:text |[]) (:id |oY5uujnpAd)
+                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314595541) (:text |f) (:id |9K0s0FHab)
+                                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314601587) (:text |:caches) (:id |gb-8-usz_)
+                                              |v $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314602959) (:text |params) (:id |i4qNyR3eQB)
+                                            :id |8xebXvE3z
+                                          |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314624246)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314624246) (:text |{}) (:id |HJi5RP-c1R)
+                                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314624246)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314624246) (:text |:value) (:id |U_R8lPDcR4)
+                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314624246) (:text |value) (:id |ICa_xgT0V2)
+                                                :id |S_jG-NXmYM
+                                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314624246)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314624246) (:text |:initial-loop) (:id |8VkTajRElX)
+                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314624246) (:text |the-loop) (:id |NMF2xq38Dj)
+                                                :id |BZpIisk7Eg
+                                              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314624246)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314624246) (:text |:last-hit) (:id |HYh_zsb8To)
+                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314624246) (:text |the-loop) (:id |8APjuCNOny)
+                                                :id |l6GhQ-iJXJ
+                                              |x $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314624246)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314624246) (:text |:hit-times) (:id |ebrAwS_2FW)
+                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314624246) (:text |0) (:id |n24KQdg6WU)
+                                                :id |MFx6FjkU2m
+                                            :id |v0NaDv4etW
+                                        :id |Nu7YXxtFe
+                                    :id |6K8ZdADhp
+                                :id |i3d3L7cmMh
+                              |h $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |assoc) (:id |0lG_R0fUqj)
+                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |caches) (:id |HE0CbKmIEU)
+                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |f) (:id |-vkAOUnc_z)
+                                  |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |{}) (:id |8UQbGTrC2s)
+                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:hit-times) (:id |TK17daChfUt)
-                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |0) (:id |HnyP0JpJk9m)
-                                        :id |05RX2hgcd8n
-                                    :id |hW5-fwnemDx
-                                :id |TMu0IXGO0zr
-                            :id |JWf1JlDo_gc
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |:caches) (:id |PO3lOgAN6K)
+                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |{}) (:id |XsgUXvlf4J)
+                                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |params) (:id |Hs6YmvX05v)
+                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |{}) (:id |FC83_vrFDy)
+                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |:value) (:id |W3OMJhJwHCQ)
+                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |value) (:id |2_R4AXi1HIA)
+                                                        :id |utr6dPD3yT
+                                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |:initial-loop) (:id |fT8NOREnRqX)
+                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |the-loop) (:id |vHFOmNbzf-1)
+                                                        :id |pi1j94-BHdH
+                                                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |:last-hit) (:id |s7wmBK0_uOs)
+                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |the-loop) (:id |6O1inne085H)
+                                                        :id |riondTsV5oK
+                                                      |x $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |:hit-times) (:id |HO-rvrHfvG5)
+                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |0) (:id |9XeYQf7SQsu)
+                                                        :id |9BDYhSEAuje
+                                                    :id |8wCdcbft44
+                                                :id |t_ez8QGTGS
+                                            :id |L5BnPvf0dM
+                                        :id |osl_lhRpOh
+                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |:hit-time) (:id |XaUrMaRkM04)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |0) (:id |FRGxAP__DjF)
+                                        :id |9LlbaU88Cm3
+                                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315323334)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |:initial-loop) (:id |CKVlA0UUzYb)
+                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315323334) (:text |the-loop) (:id |NfxcXSOfI5v)
+                                        :id |QZEokG1YCcx
+                                    :id |YVrgvngPpS
+                                :id |k2qde3wyWE
+                            :id |5g1XUxAeO
                         :id |f7Qa4m2Ep-r
                     :id |9SMiHHdsb4A
                 :id |obwBfR438br
@@ -371,6 +473,16 @@
           |user-scripts $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
             :data $ {}
               |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |defn) (:id |ZAnXhGkUcgBZ)
+              |w $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314907007)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314909674) (:text |defn) (:id |EERxTz6fflleaf)
+                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314921951) (:text |f2) (:id |kuDvdPjoGF)
+                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314910807)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314917485) (:text |x) (:id |yxMwna18Cx)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314918761) (:text |y) (:id |nqzYxtfqS)
+                    :id |vy7ZVgBlmN
+                :id |1alqFj3d53
               |yT $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |access-cache) (:id |iEBbxl11W5I8)
@@ -383,6 +495,7 @@
                       |x $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |4) (:id |DRVbp4I-DFpz)
                     :id |2R8FqZXA0FxE
                   |b $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1593965070349) (:text |*caches) (:id |xaOzQmnO5)
+                  |f $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314935883) (:text |f1) (:id |JzJQ9a6Yo)
                 :id |1L17TSa5omv5
               |yt $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594141647321)
                 :data $ {}
@@ -403,12 +516,36 @@
                     :id |2Oe12YSgdEHn
                   |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |10) (:id |AiQbhHzFAM0_)
                   |b $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1593965072286) (:text |*caches) (:id |GEtizLzpF8)
+                  |f $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314925895) (:text |f1) (:id |SGf6ym4zU8)
                 :id |OSZMzjJKW-dq
+              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314907007)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314909674) (:text |defn) (:id |EERxTz6fflleaf)
+                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314910449) (:text |f1) (:id |kuDvdPjoGF)
+                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314910807)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314917485) (:text |x) (:id |yxMwna18Cx)
+                    :id |vy7ZVgBlmN
+                :id |EERxTz6ffl
               |yj $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |new-loop!) (:id |5HCWGFLFRrlZ)
                   |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1593965069645) (:text |*caches) (:id |B240dbDWy8)
                 :id |UhAU3zK54pg7
+              |yD $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |write-cache!) (:id |ekkk48G7g0js)
+                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |[]) (:id |n9kYgZ01NtSH)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |1) (:id |IHNqg2yEdXae)
+                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |2) (:id |gV3YsYwaW3bW)
+                      |v $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |3) (:id |j3vU7gfGOiME)
+                    :id |oxwtFJDF1QRS
+                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |6) (:id |c2lRsJ9qsOkn)
+                  |b $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1593965071380) (:text |*caches) (:id |7kA00sDeK)
+                  |f $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314932034) (:text |f2) (:id |MrimxY-XBw)
+                :id |4DwuIaQQ1
               |yb $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |access-cache) (:id |iEBbxl11W5I8)
@@ -420,6 +557,7 @@
                       |v $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |3) (:id |iXHOhGBXTCUc)
                     :id |2R8FqZXA0FxE
                   |b $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1593965070349) (:text |*caches) (:id |xaOzQmnO5)
+                  |f $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314939190) (:text |f1) (:id |O4nnvsu_MO)
                 :id |MhPkEEung
               |t $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594141727826)
                 :data $ {}
@@ -465,12 +603,18 @@
                     :id |oxwtFJDF1QRS
                   |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |6) (:id |c2lRsJ9qsOkn)
                   |b $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1593965071380) (:text |*caches) (:id |7kA00sDeK)
+                  |f $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314926696) (:text |f1) (:id |MrimxY-XBw)
                 :id |3hSkCU0K6GqX
               |yn $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594142067809)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142067809) (:text |show-summary!) (:id |5OfRQ5LEHG)
                   |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142067809) (:text |*caches) (:id |eFhFUnB_bz)
                 :id |s5wzdP8p2b
+              |yw $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315239781)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315342284) (:text |identity) (:id |6VtXC2-n7leaf)
+                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315252053) (:text |@*caches) (:id |0ayX5Hye9r)
+                :id |6VtXC2-n7
             :id |rKcbjAqBNBk6
           |perform-gc! $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
             :data $ {}
@@ -523,102 +667,146 @@
                           |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |fn) (:id |HsTTwWYud02)
                           |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |UR3ycAsnDgJ)
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315117409) (:text |dict) (:id |UR3ycAsnDgJ)
                             :id |E5LSbVqVyYh
-                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315118968)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |->>) (:id |xQD61SWSNQ1)
-                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |7bdsX5n-t8p)
-                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                              |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315124276)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |remove) (:id |cfG99hn-1e5)
-                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                  |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315131182)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |fn) (:id |gm5HXBDt9GK)
-                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                      |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315142680)
                                         :data $ {}
-                                          |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |[]) (:id |Glrc7UlqgPm)
-                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |y5jA2SFBGyn)
-                                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |vvXW2NRkHJ5)
-                                            :id |hF25XHL7iVo
-                                        :id |orza7y7c5LH
-                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |cond) (:id |-dxbddGxCAb)
-                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                          |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315160142)
                                             :data $ {}
                                               |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |zero?) (:id |gOpEeGyCGTR)
-                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |m3Kx2NFCUcY)
-                                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:hit-times) (:id |ao_jk_8uITT)
-                                                    :id |4tUpI14Fmcl
-                                                :id |aqztjVRlh7F
-                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |true) (:id |WaMfjMaAI2b)
-                                            :id |r4iJ0yQR9di
-                                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                            :data $ {}
-                                              |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |>) (:id |PCJ7TvjczWg)
-                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |-) (:id |HrS2AjPyi--)
-                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |states-0) (:id |ysWadjbMWv3)
-                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:loop) (:id |IzFKbYHnhFX)
-                                                        :id |neW5Kc2Vdb6
-                                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |e4WnqWABdCs)
-                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:hit-loop) (:id |LZEOaQUynpp)
-                                                        :id |5kMeJ3ZuxIB
-                                                    :id |odRJBuP_0wv
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |->>) (:id |xQD61SWSNQ1)
+                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |7bdsX5n-t8p)
                                                   |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |gc) (:id |pWLFw7lJrS5)
-                                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:elapse-loop) (:id |Ut5Gt9kmR9N)
-                                                    :id |jInVcXroT5p
-                                                :id |o1tF5zrFz6v
-                                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594142212979)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |true) (:id |jLr18iQoWMv)
-                                                  |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215151) (:text |do) (:id |yu5SoyZwx)
-                                                  |L $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594142215780)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |swap!) (:id |gOYDaJy2fX)
-                                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |*removed-used) (:id |tf9iBXXhH0)
-                                                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |conj) (:id |zsCkUMhb1K)
-                                                      |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594142215780)
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |remove) (:id |cfG99hn-1e5)
+                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                                                         :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |info) (:id |CoXyqGUYV8)
-                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |:hit-times) (:id |0Aeb8xHkph)
-                                                        :id |BlStHkTS-8
-                                                    :id |SGuxPQp4I1
-                                                :id |Hhv2HeLWcL
-                                            :id |3_5N7s10Dkf
-                                          |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |fn) (:id |gm5HXBDt9GK)
+                                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                            :data $ {}
+                                                              |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |[]) (:id |Glrc7UlqgPm)
+                                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |y5jA2SFBGyn)
+                                                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |vvXW2NRkHJ5)
+                                                                :id |hF25XHL7iVo
+                                                            :id |orza7y7c5LH
+                                                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |cond) (:id |-dxbddGxCAb)
+                                                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |zero?) (:id |gOpEeGyCGTR)
+                                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |m3Kx2NFCUcY)
+                                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:hit-times) (:id |ao_jk_8uITT)
+                                                                        :id |4tUpI14Fmcl
+                                                                    :id |aqztjVRlh7F
+                                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |true) (:id |WaMfjMaAI2b)
+                                                                :id |r4iJ0yQR9di
+                                                              |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |>) (:id |PCJ7TvjczWg)
+                                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |-) (:id |HrS2AjPyi--)
+                                                                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |states-0) (:id |ysWadjbMWv3)
+                                                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:loop) (:id |IzFKbYHnhFX)
+                                                                            :id |neW5Kc2Vdb6
+                                                                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |e4WnqWABdCs)
+                                                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:hit-loop) (:id |LZEOaQUynpp)
+                                                                            :id |5kMeJ3ZuxIB
+                                                                        :id |odRJBuP_0wv
+                                                                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |gc) (:id |pWLFw7lJrS5)
+                                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:elapse-loop) (:id |Ut5Gt9kmR9N)
+                                                                        :id |jInVcXroT5p
+                                                                    :id |o1tF5zrFz6v
+                                                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594142212979)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |true) (:id |jLr18iQoWMv)
+                                                                      |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215151) (:text |do) (:id |yu5SoyZwx)
+                                                                      |L $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594142215780)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |swap!) (:id |gOYDaJy2fX)
+                                                                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |*removed-used) (:id |tf9iBXXhH0)
+                                                                          |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |conj) (:id |zsCkUMhb1K)
+                                                                          |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594142215780)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |info) (:id |CoXyqGUYV8)
+                                                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594142215780) (:text |:hit-times) (:id |0Aeb8xHkph)
+                                                                            :id |BlStHkTS-8
+                                                                        :id |SGuxPQp4I1
+                                                                    :id |Hhv2HeLWcL
+                                                                :id |3_5N7s10Dkf
+                                                              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:else) (:id |gRteGerhp3z)
+                                                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |false) (:id |becpq7Us0f6)
+                                                                :id |h3xUcH7XkF8
+                                                            :id |-XChZYCXaWV
+                                                        :id |rto0NUjUiu2
+                                                    :id |LFfR1V67N6Q
+                                                  |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |into) (:id |gt1Q9L0Vg3_)
+                                                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |{}) (:id |xyL7RXiAWjr)
+                                                        :id |pXB4aNNbnuw
+                                                    :id |-PVDaxGD-bS
+                                                :id |C8RMCDUKiwk
+                                              |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315161263) (:text |fn) (:id |IhD4XDm6K9)
+                                              |L $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315161828)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315162652) (:text |caches) (:id |St7DiPmttJ)
+                                                :id |aHRpLBtROB
+                                            :id |CBtC14Fzu
+                                          |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315145283) (:text |update) (:id |5-rXnPOUCR)
+                                          |L $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315146790) (:text |info) (:id |DVyze-Niyc)
+                                          |P $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315148599) (:text |:caches) (:id |x2Yhs-JZgM)
+                                        :id |7UzbGvk4b
+                                      |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315131786) (:text |fn) (:id |2sg9JblREJ)
+                                      |L $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315132391)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315133573)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:else) (:id |gRteGerhp3z)
-                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |false) (:id |becpq7Us0f6)
-                                            :id |h3xUcH7XkF8
-                                        :id |-XChZYCXaWV
-                                    :id |rto0NUjUiu2
-                                :id |LFfR1V67N6Q
-                              |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315134768) (:text |[]) (:id |4BwUNMhl10)
+                                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315135654) (:text |f) (:id |JHpz8XyIB)
+                                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315138376) (:text |info) (:id |NSaQsnQqj)
+                                            :id |iSpRdsTE7
+                                        :id |7AOCandHr
+                                    :id |TU4lbhbVi
+                                  |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315128973) (:text |map) (:id |C3JgSlvys)
+                                :id |Graw2D80_
+                              |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315120746) (:text |->>) (:id |h_zihvu-E)
+                              |L $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315122329) (:text |dict) (:id |7oYkN6QVC0)
+                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315151984)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |into) (:id |gt1Q9L0Vg3_)
-                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315152655) (:text |into) (:id |EXUtvwsSpMleaf)
+                                  |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315153198)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |{}) (:id |xyL7RXiAWjr)
-                                    :id |pXB4aNNbnuw
-                                :id |-PVDaxGD-bS
-                            :id |C8RMCDUKiwk
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315153558) (:text |{}) (:id |QbGY90hNp-)
+                                    :id |H3a9xcdGy
+                                :id |EXUtvwsSpM
+                            :id |34jAxP44WO
                         :id |dhzc_bhW0pB
                     :id |gM7NLg5uKaR
                   |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594142232712)
@@ -705,8 +893,8 @@
                           |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |[]) (:id |hKpPyjj1ly3z)
-                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |ou9IPEU-ICqj)
-                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |H_kNbvjE5t5h)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314997503) (:text |f) (:id |ou9IPEU-ICqj)
+                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315027809) (:text |dict) (:id |H_kNbvjE5t5h)
                             :id |br02nrESYYTh
                           |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                             :data $ {}
@@ -715,18 +903,45 @@
                             :id |1bNt9_B6oLRK
                         :id |_x-MmC8Jxxxs
                     :id |ILJZ4szUa_cD
-                  |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                  |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315001884)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |println) (:id |xSFD62U8E61Z)
-                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594228331702) (:text "|\"INFO:") (:id |JD_PRM4j2tFj)
-                      |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                      |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |assoc) (:id |NLDbtH1oLnRA)
-                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |Ev0Y-pwDrva6)
-                          |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:value) (:id |Ui01J2omqmy9)
-                          |v $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |'VALUE) (:id |Fhiou0HsIQKW)
-                        :id |2iSCbzBC7HWg
-                    :id |0TfSMBEBRjo6
+                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |println) (:id |xSFD62U8E61Z)
+                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594228331702) (:text "|\"INFO:") (:id |JD_PRM4j2tFj)
+                          |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |assoc) (:id |NLDbtH1oLnRA)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |info) (:id |Ev0Y-pwDrva6)
+                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:value) (:id |Ui01J2omqmy9)
+                              |v $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |'VALUE) (:id |Fhiou0HsIQKW)
+                            :id |2iSCbzBC7HWg
+                        :id |0TfSMBEBRjo6
+                      |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315004674) (:text |doseq) (:id |OP3cM_zL8)
+                      |L $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315005552)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315005741)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315008952)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315008668) (:text |[]) (:id |A3M2_4ylM)
+                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315013587) (:text |params) (:id |1CA2h3pEl)
+                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315018382) (:text |info) (:id |TKHTPJAa8)
+                                :id |ZRhWSfsnZP
+                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315030375)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315040052) (:text |:caches) (:id |nrpHtFSBQ)
+                                  |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315040978) (:text |dict) (:id |_hovnWNnq)
+                                :id |Ejal2HzHmq
+                            :id |uXhbBCUMpM
+                        :id |YNHzdcpoB6
+                    :id |NIPROaKm7D
+                  |p $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594315050158)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315053111) (:text |println) (:id |dEg2LNgYAleaf)
+                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315061590) (:text "|\"FUNCTION..") (:id |k7pb4abFHb)
+                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594315445641) (:text |f) (:id |aYVuiXCz4)
+                    :id |dEg2LNgYA
                 :id |TT6wU9jkd8x4
               |w $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594228344626)
                 :data $ {}
@@ -746,6 +961,7 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |_QXJDQddy0Z)
                   |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1593965124320) (:text |*cache-states) (:id |7hh4WiPtP)
+                  |L $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314760692) (:text |f) (:id |-C8-OAObg)
                 :id |GqzFp8_CyNZ
               |v $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                 :data $ {}
@@ -774,12 +990,31 @@
                   |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |if) (:id |sROH51KzXlS)
-                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                      |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314788172)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |contains?) (:id |JFYDZ-Zkpkh0)
-                          |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |2ppg1_-c3WP1)
-                          |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |r0HnGZAQ_gu-)
-                        :id |lQ8qtNfgZtn
+                          |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |contains?) (:id |JFYDZ-Zkpkh0)
+                              |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |2ppg1_-c3WP1)
+                              |n $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314784041) (:text |f) (:id |veJy3Rso-)
+                            :id |lQ8qtNfgZtn
+                          |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314789726) (:text |and) (:id |X0mEDU5i0v)
+                          |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314791372)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314796525) (:text |contains?) (:id |tFx8zBOpxleaf)
+                              |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314801917)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314797619)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314798055) (:text |get) (:id |qf_D0XQGlP)
+                                      |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314800228) (:text |caches) (:id |Hg7Oju7LX)
+                                      |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314800920) (:text |f) (:id |LgdypuZK29)
+                                    :id |ggEnT1USW
+                                  |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314805557) (:text |:caches) (:id |tuzwXLUny)
+                                :id |LMqxbmCIvv
+                              |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314808892) (:text |params) (:id |IR1ry57Ag)
+                            :id |tFx8zBOpx
+                        :id |XEuHxa8f1
                       |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |do) (:id |HUZBidz6fN1u)
@@ -797,6 +1032,8 @@
                                               |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |[]) (:id |CYZ1NvnwF1y6)
                                               |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:caches) (:id |l7oKIQj1jTSQ)
                                               |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |3wYDRVkOo2de)
+                                              |n $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314853038) (:text |f) (:id |MxEPYufQHp)
+                                              |p $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314856596) (:text |:caches) (:id |umMpbTZra)
                                             :id |BiGgMxcuL2SQ
                                           |x $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                                             :data $ {}
@@ -865,9 +1102,15 @@
                               |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |:value) (:id |xaKAoPD7o_QM)
                               |j $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1592323714536)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |get) (:id |xJkJxtwG_oLB)
+                                  |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314871890) (:text |get-in) (:id |xJkJxtwG_oLB)
                                   |j $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |caches) (:id |Pcnkqb4kNtv8)
-                                  |r $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |ndiOidVllJw_)
+                                  |r $ {} (:type :expr) (:by |yeKFqj7rX) (:at 1594314875244)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1592323714536) (:text |params) (:id |ndiOidVllJw_)
+                                      |D $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314875866) (:text |[]) (:id |DB9R1M0q2S)
+                                      |L $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314876240) (:text |f) (:id |ZRhlpLvcyr)
+                                      |P $ {} (:type :leaf) (:by |yeKFqj7rX) (:at 1594314880062) (:text |:caches) (:id |K9gEsYyuT8)
+                                    :id |X8bGWW59-
                                 :id |tP4VMEFwvEE3
                             :id |ehgSX85OxzJ_
                         :id |wld3jWgD7u3_


### PR DESCRIPTION
Intent of this PR is to refactor caching structure by splitting caches by functions. Very roughly:

```edn
{
  :caches {
    f1 {
      :caches {
        params {:value "VALUE" :hit-times 1 :last-hit-loop 1}
      }
    }
    f2 {
      :caches {
        params {:value "VALUE" :hit-times 1 :last-hit-loop 1}
      }
    }
  }
}
```

Use cases in Cumulo and Respo request for a structure like this. And it's supposed to fit better in the scenarios it's being used, memoizing function by arguments.

This is not a complete refactor. There will be changes in the future. And it's breaking to downstream libraries.
